### PR TITLE
feat: bump clevertap version to 7.3.1

### DIFF
--- a/.github/workflows/snapshot_release.yml
+++ b/.github/workflows/snapshot_release.yml
@@ -13,6 +13,11 @@ jobs:
       - name: Checkout source branch
         uses: actions/checkout@v4
 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'com.android.tools.build:gradle:8.6.1'
         // To be added only when using the Push Notification Service of CleverTap
         // classpath 'com.google.gms:google-services:4.3.5'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath 'com.android.tools.build:gradle:8.1.0'
         // To be added only when using the Push Notification Service of CleverTap
         // classpath 'com.google.gms:google-services:4.3.5'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.7.3'
         // To be added only when using the Push Notification Service of CleverTap
         // classpath 'com.google.gms:google-services:4.3.5'
     }

--- a/clevertap/build.gradle
+++ b/clevertap/build.gradle
@@ -3,11 +3,15 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdk 33
+    namespace 'com.rudderstack.android.integration.clevertap'
+    compileSdk 34
+
+    buildFeatures {
+        buildConfig = true
+    }
 
     defaultConfig {
-        minSdkVersion 19
-        targetSdk 33
+        minSdkVersion 21
         buildConfigField("String", "VERSION_NAME", "\"${VERSION_NAME}\"")
     }
 
@@ -27,7 +31,7 @@ dependencies {
     // RudderStack SDK
     compileOnly 'com.rudderstack.android.sdk:core:[1.23.3, 2.0.0)'
     // CleverTap SDK
-    implementation 'com.clevertap.android:clevertap-android-sdk:[6.2.1, 7.0.0)'
+    implementation 'com.clevertap.android:clevertap-android-sdk:7.3.1'
 
     implementation 'androidx.annotation:annotation:1.7.0'
     implementation 'com.google.code.gson:gson:2.10.1'

--- a/clevertap/src/main/AndroidManifest.xml
+++ b/clevertap/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.rudderstack.android.integrations.clevertap">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/gradle/codecov.gradle
+++ b/gradle/codecov.gradle
@@ -29,9 +29,9 @@ task codeCoverageReport(type: JacocoReport) {
     executionData.setFrom(execData)
 
     reports {
-        xml.enabled true
-        xml.destination file("${buildDir}/reports/jacoco/report.xml")
-        html.enabled true
-        csv.enabled false
+        xml.required.set true
+        xml.outputLocation.set file("${buildDir}/reports/jacoco/report.xml")
+        html.required.set true
+        csv.required.set false
     }
 }

--- a/gradle/mvn-publish.gradle
+++ b/gradle/mvn-publish.gradle
@@ -83,6 +83,12 @@ signing {
     sign publishing.publications
 }
 
+if(POM_PACKAGING == "aar"){
+    tasks.named("signReleasePublication").configure { dependsOn("bundleReleaseAar") }
+}else{
+    tasks.named("signReleasePublication").configure { dependsOn("jar") }
+}
+
 publish.dependsOn build
 publishToMavenLocal.dependsOn build
 publishToSonatype.dependsOn publish

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Apr 07 12:00:28 IST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Apr 07 12:00:28 IST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 14 23:20:24 IST 2023
+#Mon Apr 07 12:00:28 IST 2025
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0"
     }
 }
 
@@ -19,11 +19,15 @@ if (project.rootProject.file('sample-kotlin/local.properties').canRead()) {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdk 35
+
+    buildFeatures {
+        buildConfig = true
+    }
+
     defaultConfig {
         applicationId "com.rudderstack.sample.clevertap.android"
-        minSdkVersion 19
-        targetSdkVersion 33
+        minSdkVersion 21
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -40,8 +44,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     namespace 'com.rudderlabs.android.sample.kotlin'
 }
@@ -51,8 +55,8 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10"
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.core:core-ktx:1.15.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
     implementation 'com.rudderstack.android.sdk:core:[1.23.1,2.0)'


### PR DESCRIPTION
## Description
This PR does below things:
1. Updates the clevertap version to `7.3.1`.
2. Updates the `compileSdk` for clevertap integration from 33 to 34.
3. Updates the agp version to `8.6.1`.
4. Updates the deprecated code in `codecov.gradle` file.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] Version upgraded (project, README, gradle, podspec etc)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
