### PR TITLE
chore(ci): migrate all workflows from PAT to GITHUB_TOKEN/App Token [SEC-58]

### DIFF
--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -27,6 +27,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
           permission-contents: write # to create commits and push changes
           permission-pull-requests: write # to create and update PRs
+          permission-members: read # to resolve team reviewers
 
       - name: Checkout source branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -39,15 +39,8 @@ jobs:
         with:
           node-version: 16
 
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
-        run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
-
       # Calculate the next release version based on conventional semantic release
-      - name: Create release branch
+      - name: Calculate release version
         id: create-release
         run: |
           source_branch_name=${GITHUB_REF##*/}
@@ -68,17 +61,20 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
-          git checkout -b "$branch_name"
 
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
-      - name: Push release branch
+      - name: Create release branch via API
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
-          git push --set-upstream origin "${{ steps.create-release.outputs.branch_name }}"
+          BASE_SHA=$(git rev-parse origin/master)
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
+            -f sha="$BASE_SHA"
 
       - name: Update changelog & bump version
         id: finish-release

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -55,7 +55,7 @@ jobs:
           git fetch origin master --depth=1
           git merge origin/master
           current_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
-          
+
           npm ci
           npx standard-version --skip.commit --skip.tag --skip.changelog
           new_version=$(cat gradle.properties | grep "VERSION_NAME" | cut -d'=' -f2)
@@ -69,21 +69,33 @@ jobs:
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
           git checkout -b "$branch_name"
-          git push --set-upstream origin "$branch_name"
 
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
+      - name: Push release branch
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          git push --set-upstream origin "${{ steps.create-release.outputs.branch_name }}"
+
       - name: Update changelog & bump version
         id: finish-release
         run: |
           npm ci
-          npx standard-version -a --skip.tag
+          npx standard-version -a --skip.commit --skip.tag
 
-      - name: Push new version in release branch
-        run: |
-          git push
+      - name: Create verified commit via API
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: ${{ steps.create-release.outputs.branch_name }}
+          commit-message: 'chore(release): v${{ steps.create-release.outputs.new_version }}'
+          files: |
+            CHANGELOG.md
+            gradle.properties
 
       - name: Create pull request into master
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 #v2

--- a/.github/workflows/draft_new_release.yml
+++ b/.github/workflows/draft_new_release.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   draft-new-release:
     permissions:
-      contents: write  # for Git to git push
+      contents: read # minimal permissions for GITHUB_TOKEN, actual operations use App Token
     name: Draft a new release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/fix/')
@@ -19,10 +19,20 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits and push changes
+          permission-pull-requests: write # to create and update PRs
+
       - name: Checkout source branch
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set Node 16
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -80,7 +90,7 @@ jobs:
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'master'
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body:  ":crown: *An automated PR*"
           pr_reviewer: '@rudderlabs/sdk-android'

--- a/.github/workflows/notion_pr_sync.yml
+++ b/.github/workflows/notion_pr_sync.yml
@@ -46,6 +46,8 @@ on:
 jobs:
   request:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # to read PR metadata for Notion sync
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
@@ -57,4 +59,4 @@ jobs:
         with:
           notionKey: ${{ secrets.NOTION_BOT_KEY }}
           notionDatabaseId: ${{ secrets.NOTION_PR_DB_ID }}
-          githubKey: ${{ secrets.PAT }}
+          githubKey: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-new-github-release.yml
+++ b/.github/workflows/publish-new-github-release.yml
@@ -15,12 +15,23 @@ jobs:
   release:
     name: Publish new release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # minimal permissions for GITHUB_TOKEN, actual operations use App Token
     if: ${{ github.event_name == 'workflow_dispatch' }} || (startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.merged == true) # only merged pull requests must trigger this job
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
         with:
           egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create tags and releases
+          permission-pull-requests: write # to read PR metadata
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
@@ -37,6 +48,7 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -53,8 +65,7 @@ jobs:
       - name: Create GitHub Release & Tag
         id: create_release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.PAT }}
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           git tag -a v${{ steps.extract-version.outputs.release_version }} -m "chore: release v${{ steps.extract-version.outputs.release_version }}"
           git push origin refs/tags/v${{ steps.extract-version.outputs.release_version }}
@@ -66,4 +77,4 @@ jobs:
         with:
           branches: 'release/*'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/publish-new-github-release.yml
+++ b/.github/workflows/publish-new-github-release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # minimal permissions for GITHUB_TOKEN, actual operations use App Token
-    if: ${{ github.event_name == 'workflow_dispatch' }} || (startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.merged == true) # only merged pull requests must trigger this job
+    if: github.event_name == 'workflow_dispatch' || (startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.merged == true) # only merged pull requests must trigger this job
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@95d9a5deda9de15063e7595e9719c11c38c90ae2 # v2.13.2
@@ -35,13 +35,16 @@ jobs:
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          VERSION_INPUT: ${{ github.event.inputs.version }}
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
-          if [ "$BRANCH_NAME" = "" ]; then BRANCH_NAME=${{ github.event.inputs.version }}
+          BRANCH_NAME="${PR_HEAD_REF}"
+          if [ "$BRANCH_NAME" = "" ]; then BRANCH_NAME="${VERSION_INPUT}"
           fi
           echo "BRANCH_NAME considered: ${BRANCH_NAME}"
           VERSION=${BRANCH_NAME#release/}
-          
+
           echo "release_version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Checkout
@@ -66,6 +69,7 @@ jobs:
         id: create_release
         env:
           CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           git tag -a v${{ steps.extract-version.outputs.release_version }} -m "chore: release v${{ steps.extract-version.outputs.release_version }}"
           git push origin refs/tags/v${{ steps.extract-version.outputs.release_version }}


### PR DESCRIPTION
## Summary

This PR completes the migration from PAT to GitHub App tokens and simplifies the draft_new_release workflow by using the new GitHub API-based pattern for branch creation and signed commits.

### Migration Details

| File | Change | Why |
|------|--------|-----|
| `draft_new_release.yml` | Use GitHub API for branch creation instead of `git push --set-upstream` | Eliminates need for git config and token-in-URL patterns. Cleaner, more secure approach |
| `draft_new_release.yml` | Remove git config user.name/email steps | No longer needed - signed-commit action uses App identity |
| `draft_new_release.yml` | Keep `--skip.commit --skip.tag` for standard-version | Files modified on disk, commits created via API for verification |
| `publish-new-github-release.yml` | Fix template-injection vulnerabilities | Prevents attackers from injecting malicious code via PR titles/branch names |
| `publish-new-github-release.yml` | Fix unsound-condition issue | Removes unnecessary \${{ }} wrapper to ensure condition evaluates correctly |

### Key Changes to draft_new_release.yml

**REMOVED (No longer needed with API approach):**
- `git config user.name/email` steps
- `git push --set-upstream origin` command

**ADDED (Cleaner API-based pattern):**
```yaml
- name: Create release branch via API
  env:
    GH_TOKEN: ${{ steps.generate-token.outputs.token }}
  run: |
    BASE_SHA=$(git rev-parse origin/master)
    gh api repos/${{ github.repository }}/git/refs \
      --method POST \
      -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
      -f sha="$BASE_SHA"
```

This pattern:
- Creates branches via GitHub API (no git push needed)
- Works seamlessly with ryancyq/github-signed-commit action
- No need for token-in-URL or git config setup
- More secure and maintainable

### Security Fixes in publish-new-github-release.yml

#### Template Injection (High Severity)
- **Issue**: `${{ github.event.pull_request.head.ref }}` and `${{ github.event.inputs.version }}` used directly in shell scripts
- **Fix**: Pass through environment variables to prevent code injection
- **Impact**: Prevents attackers from executing arbitrary code via malicious PR branch names or workflow inputs

#### Unsound Condition
- **Issue**: `if: ${{ ... }} || ...` wrapping causes entire condition to always be true
- **Fix**: Remove unnecessary `${{ }}` wrapper
- **Impact**: Ensures workflow only runs when intended

### Benefits of the New Pattern

1. **Simplified code**: Removed 4 lines of git config/push commands
2. **More secure**: No token embedded in git remote URL
3. **Verified commits**: All commits show green checkmark via GitHub API
4. **Better separation**: Branch creation separate from commit creation

### Reference Documentation

- Plan: PAT_MIGRATION_AGENT_PLAN.md - "Creating Release Branches (Use GitHub API, NOT git push)"
- Similar pattern in: rudder-consent-filters-android PR #21

### Linting Results

All changes validated with:
- ✅ `actionlint` - No new issues introduced
- ✅ `zizmor` (medium+ severity) - Template injection and unsound-condition fixed

Pre-existing shellcheck warnings (SC2086, SC2129) and archived-uses warning for repo-sync/pull-request intentionally not fixed per migration plan.

## Test plan

- [ ] Verify draft_new_release workflow creates release branch successfully
- [ ] Verify commits are verified (green checkmark on GitHub)
- [ ] Verify publish-new-github-release workflow creates tags successfully
- [ ] Verify all CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)